### PR TITLE
Fix double printing for WrapperSignal.

### DIFF
--- a/repository/Beacon-Core.package/WrapperSignal.class/instance/printOn..st
+++ b/repository/Beacon-Core.package/WrapperSignal.class/instance/printOn..st
@@ -1,5 +1,0 @@
-printing
-printOn: stream
-	super printOn: stream.
-	stream space.
-	self target printOn: stream 


### PR DESCRIPTION
printOneLineContentsOn: stream already calls self target printOn: stream