### PR TITLE
Fix FileLogger for Pharo 10

### DIFF
--- a/repository/Beacon-File.package/FileLogger.class/instance/converter.st
+++ b/repository/Beacon-File.package/FileLogger.class/instance/converter.st
@@ -1,3 +1,0 @@
-accessing
-converter
-	^ TextConverter newForEncoding: self encoding

--- a/repository/Beacon-File.package/FileLogger.class/instance/encoder.st
+++ b/repository/Beacon-File.package/FileLogger.class/instance/encoder.st
@@ -1,0 +1,3 @@
+accessing
+encoder
+	^ ZnCharacterEncoder newForEncoding: self encoding

--- a/repository/Beacon-File.package/FileLogger.class/instance/newStream.st
+++ b/repository/Beacon-File.package/FileLogger.class/instance/newStream.st
@@ -3,5 +3,5 @@ newStream
 	| newStream |
 	newStream := fileReference writeStream.
 	binary ifFalse: [ 
-		newStream converter: self converter ].
+		newStream encoder: self encoder ].
 	^ newStream 


### PR DESCRIPTION
This PR fixes `FileLogger` for Pharo 10 by replacing the converter with `ZnCharacterEncoder` and changing the `newStream` method.

This also fixes #10.

Cheers